### PR TITLE
Change of the REST service's url for the VEP viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #pViz.js/VEP viewer: A browser side only application to view Ensemble Variant Effect Predictor output files
 The [Ensembl Variant Effect Predictor](http://ensembl.ebi.com/vep) produces '.vep' files with, among others, protein positioned features of variant.
 
-We propose a tool to parse such an output, retrieve the protein sequence from [Ensembl REST API](http://beta.rest.ensembl.org), and align the features on the sequence, grouped by categories.
+We propose a tool to parse such an output, retrieve the protein sequence from [Ensembl REST API](http://rest.ensembl.org), and align the features on the sequence, grouped by categories.
 ##Data sources
 Any '.vep' file can be fitted in the tool, either on of the test set or a loaded local files. Files with up to 1.5M lines can be parsed in a chrome browser in approximatively 10 seconds.
 ###Parsed features

--- a/app/scripts/templates/configure.ejs
+++ b/app/scripts/templates/configure.ejs
@@ -15,7 +15,7 @@
                     <div class="form-group">
                         <label for="inputEmail3" class="col-sm-3 control-label">ensembl REST url</label>
                         <div class="col-sm-9">
-                            <input type="text" class="input form-control configure-param" name="url_ensembl_rest" placeholder="http://beta.rest.ensembl.org/sequence/id">
+                            <input type="text" class="input form-control configure-param" name="url_ensembl_rest" placeholder="http://rest.ensembl.org/sequence/id">
                         </div>
                     </div>
                     <div class="form-group">
@@ -30,4 +30,3 @@
         </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
-

--- a/app/scripts/templates/help.ejs
+++ b/app/scripts/templates/help.ejs
@@ -14,7 +14,7 @@
                         .vep
                     </code>
                     files with, among others, protein positioned features of variant.
-                    We propose a tool to parse such an output, retrieve the protein sequence from <a href="http://beta.rest.ensembl.org/">Ensembl REST API</a>, and align the features on the sequence,grouped by categories.
+                    We propose a tool to parse such an output, retrieve the protein sequence from <a href="http://rest.ensembl.org/">Ensembl REST API</a>, and align the features on the sequence,grouped by categories.
                 </p>
                 <p>
                     <h4>Data sources</h4>
@@ -32,13 +32,13 @@
 
                     <h4>A note to developers</h4>
                         Clone the project, then <code>npm install</code> and <code>grunt server</code>. That should make it work!
-                        
+
                      <h4>Authors</h4>
                     This application is based on the versatile <a href="http://github.com/genentech/pviz">pViz.js: a dynamic JavaScript and SVG library for visualization of protein sequence features</a> JavaScript library, written by <a href="mailto://masselot.alexandre@gene.com">Alexandre Masselot</a> and <a href="mailto://mukhyala.kiran@gene.com">Kiran Mukhyala</a>, from the Bioinfromatics & Computational Biology Department, at <a href="http://www.gene.com">Genentech Inc.</a> Research. <h4>Reference</h4>
                     Please provide a reference to this application by citing:
                     <pre>xxx.xx 2014</pre>
                     <h4>Thanks to</h4>
-                    This app is aimed at demonstrating pViz library. But it would never have existed without a myriad of other useful an inspiring projects: <a href="http://d3js.org">d3.js</a>, 
+                    This app is aimed at demonstrating pViz library. But it would never have existed without a myriad of other useful an inspiring projects: <a href="http://d3js.org">d3.js</a>,
                         <a href="http://colorbrewer2.org/">color brewer</a> (and Mike Bostock <a href="http://bl.ocks.org/mbostock/5577023">implementation</a>), <a href="http://gruntjs.com/">grunt</a>, <a href="https://npmjs.org/package/bower">bower</a>, <a href="http://getbootstrap.com/css/">bootstrap</a>, <a href="http://jquery.com/">jquery</a> (and <a href="https://github.com/carhartl/jquery-cookie">$.cookie</a>, <a href="http://backbonejs.org/">backbone</a>, <a href="http://requirejs.org/">require.js</a>, <a href="http://underscorejs.org/">underscore</a>, <a href="http://twitter.github.io/typeahead.js/">typeahead</a>, <a href="http://misoproject.com/dataset/">Miso.dataset</a> and a few others.
 
                     <h4>Licence</h4>


### PR DESCRIPTION
I removed the "beta" in the url to use the released service instead of the beta. 
